### PR TITLE
add mock plaid transactions API

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,7 @@ const cookieParser = require('cookie-parser');
 
 const authRouter = require('./routes/authRoutes');
 const userRouter = require('./routes/userRoutes');
+const transactionRouter = require('./routes/transactionRoutes');
 
 const app = express();
 
@@ -37,5 +38,8 @@ app.get('/api/greetings', (req, res) => {
 app.get('/api/health', (req, res) => {
   res.json({ status: 'OK', message: 'Server is running!' });
 });
+
+// Transaction Routes
+app.use(transactionRouter);
 
 module.exports = app;

--- a/server/mock/plaid_transaction.json
+++ b/server/mock/plaid_transaction.json
@@ -1,0 +1,170 @@
+{
+    "accounts": [
+      {
+        "account_id": "BxBXxLj1m4HMXBm9WZZmCWVbPjX16EHwv99vp",
+        "balances": {
+          "available": 110.94,
+          "current": 110.94,
+          "iso_currency_code": "USD",
+          "limit": null,
+          "unofficial_currency_code": null
+        },
+        "mask": "0000",
+        "name": "Plaid Checking",
+        "official_name": "Plaid Gold Standard 0% Interest Checking",
+        "subtype": "checking",
+        "type": "depository"
+      }
+    ],
+    "transactions": [
+      {
+        "account_id": "BxBXxLj1m4HMXBm9WZZmCWVbPjX16EHwv99vp",
+        "account_owner": null,
+        "amount": 28.34,
+        "iso_currency_code": "USD",
+        "unofficial_currency_code": null,
+        "check_number": null,
+        "counterparties": [
+          {
+            "name": "DoorDash",
+            "type": "marketplace",
+            "logo_url": "https://plaid-counterparty-logos.plaid.com/doordash_1.png",
+            "website": "doordash.com",
+            "entity_id": "YNRJg5o2djJLv52nBA1Yn1KpL858egYVo4dpm",
+            "confidence_level": "HIGH"
+          },
+          {
+            "name": "Burger King",
+            "type": "merchant",
+            "logo_url": "https://plaid-merchant-logos.plaid.com/burger_king_155.png",
+            "website": "burgerking.com",
+            "entity_id": "mVrw538wamwdm22mK8jqpp7qd5br0eeV9o4a1",
+            "confidence_level": "VERY_HIGH"
+          }
+        ],
+        "date": "2023-09-28",
+        "datetime": "2023-09-28T15:10:09Z",
+        "authorized_date": "2023-09-27",
+        "authorized_datetime": "2023-09-27T08:01:58Z",
+        "location": {
+          "address": null,
+          "city": null,
+          "region": null,
+          "postal_code": null,
+          "country": null,
+          "lat": null,
+          "lon": null,
+          "store_number": null
+        },
+        "name": "Dd Doordash Burgerkin",
+        "merchant_name": "Burger King",
+        "merchant_entity_id": "mVrw538wamwdm22mK8jqpp7qd5br0eeV9o4a1",
+        "logo_url": "https://plaid-merchant-logos.plaid.com/burger_king_155.png",
+        "website": "burgerking.com",
+        "payment_meta": {
+          "by_order_of": null,
+          "payee": null,
+          "payer": null,
+          "payment_method": null,
+          "payment_processor": null,
+          "ppd_id": null,
+          "reason": null,
+          "reference_number": null
+        },
+        "payment_channel": "online",
+        "pending": true,
+        "pending_transaction_id": null,
+        "personal_finance_category": {
+          "primary": "FOOD_AND_DRINK",
+          "detailed": "FOOD_AND_DRINK_FAST_FOOD",
+          "confidence_level": "VERY_HIGH"
+        },
+        "personal_finance_category_icon_url": "https://plaid-category-icons.plaid.com/PFC_FOOD_AND_DRINK.png",
+        "transaction_id": "yhnUVvtcGGcCKU0bcz8PDQr5ZUxUXebUvbKC0",
+        "transaction_code": null,
+        "transaction_type": "digital"
+      },
+      {
+        "account_id": "BxBXxLj1m4HMXBm9WZZmCWVbPjX16EHwv99vp",
+        "account_owner": null,
+        "amount": 72.1,
+        "iso_currency_code": "USD",
+        "unofficial_currency_code": null,
+        "check_number": null,
+        "counterparties": [
+          {
+            "name": "Walmart",
+            "type": "merchant",
+            "logo_url": "https://plaid-merchant-logos.plaid.com/walmart_1100.png",
+            "website": "walmart.com",
+            "entity_id": "O5W5j4dN9OR3E6ypQmjdkWZZRoXEzVMz2ByWM",
+            "confidence_level": "VERY_HIGH"
+          }
+        ],
+        "date": "2023-09-24",
+        "datetime": "2023-09-24T11:01:01Z",
+        "authorized_date": "2023-09-22",
+        "authorized_datetime": "2023-09-22T10:34:50Z",
+        "location": {
+          "address": "13425 Community Rd",
+          "city": "Poway",
+          "region": "CA",
+          "postal_code": "92064",
+          "country": "US",
+          "lat": 32.959068,
+          "lon": -117.037666,
+          "store_number": "1700"
+        },
+        "name": "PURCHASE WM SUPERCENTER #1700",
+        "merchant_name": "Walmart",
+        "merchant_entity_id": "O5W5j4dN9OR3E6ypQmjdkWZZRoXEzVMz2ByWM",
+        "logo_url": "https://plaid-merchant-logos.plaid.com/walmart_1100.png",
+        "website": "walmart.com",
+        "payment_meta": {
+          "by_order_of": null,
+          "payee": null,
+          "payer": null,
+          "payment_method": null,
+          "payment_processor": null,
+          "ppd_id": null,
+          "reason": null,
+          "reference_number": null
+        },
+        "payment_channel": "in store",
+        "pending": false,
+        "pending_transaction_id": "no86Eox18VHMvaOVL7gPUM9ap3aR1LsAVZ5nc",
+        "personal_finance_category": {
+          "primary": "GENERAL_MERCHANDISE",
+          "detailed": "GENERAL_MERCHANDISE_SUPERSTORES",
+          "confidence_level": "VERY_HIGH"
+        },
+        "personal_finance_category_icon_url": "https://plaid-category-icons.plaid.com/PFC_GENERAL_MERCHANDISE.png",
+        "transaction_id": "lPNjeW1nR6CDn5okmGQ6hEpMo4lLNoSrzqDje",
+        "transaction_code": null,
+        "transaction_type": "place"
+      }
+    ],
+    "item": {
+      "available_products": [
+        "balance",
+        "identity",
+        "investments"
+      ],
+      "billed_products": [
+        "assets",
+        "auth",
+        "liabilities",
+        "transactions"
+      ],
+      "consent_expiration_time": null,
+      "error": null,
+      "institution_id": "ins_3",
+      "institution_name": "Chase",
+      "item_id": "eVBnVMp7zdTJLkRNr33Rs6zr7KNJqBFL9DrE6",
+      "update_type": "background",
+      "webhook": "https://www.genericwebhookurl.com/webhook",
+      "auth_method": "INSTANT_AUTH"
+    },
+    "total_transactions": 1,
+    "request_id": "45QSn"
+  }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,7 +15,7 @@
         "cookie": "^1.0.2",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
-        "dotenv": "^17.1.0",
+        "dotenv": "^17.2.0",
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.16.2",
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.1.0.tgz",
-      "integrity": "sha512-tG9VUTJTuju6GcXgbdsOuRhupE8cb4mRgY5JLRCh4MtGoVo3/gfGUtOMwmProM6d0ba2mCFvv+WrpYJV6qgJXQ==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,7 @@
     "cookie": "^1.0.2",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
-    "dotenv": "^17.1.0",
+    "dotenv": "^17.2.0",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.16.2",

--- a/server/routes/transactionRoutes.js
+++ b/server/routes/transactionRoutes.js
@@ -1,0 +1,27 @@
+// Mock Plaid API for Transaction Dashboard
+
+const { error } = require('console');
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const router = express.Router();
+
+router.get('/api/transaction', (req, res)=> {
+    const filePath = path.join(__dirname, '../mock/plaid_transaction.json');
+    fs.readFile(filePath, (err, data) => {
+        if (err) {
+            console.error('Error reading files', err);
+            return res.status(500).json({error: 'Some type of error ...'});
+        }
+        try {
+            const parsedData = JSON.parse(data);
+            res.status(200).json(parsedData);
+        }
+        catch (parseError) {
+            console.error('Error pasing JSON: ', parseError);
+            res.status(500).json({error: 'Invalid JSON structure'});
+        }
+    });
+});
+
+module.exports = router;


### PR DESCRIPTION
Overview: Work on backend for Transactions Table + Filters
This PR adds a mock API endpoint to simulate Plaid's endpoint /transactions/get response for the transaction dashboard. 

- Changes Made:
+ Created plaid_transaction.json under server/mock with sample Plaid transaction data 
+ Created transactionRoutes.js under server/routes to add new route api/transaction
+ Registered the route in server/app.js
+ Tested endpoint locally using Postman on localhost:5050
<img width="1519" height="814" alt="Screenshot 2025-07-12 at 5 53 40 AM" src="https://github.com/user-attachments/assets/1579b8b7-1d8e-4505-88f0-0f2057ced77a" />

- Issue: 
+ The original server.js file included database connection logic (connectDB) that blocked the server from starting if the DB failed.
+ Temporary fix to test on Postman: commented out the DB connection and started the server manually with a hardcoded port to allow mock API testing.